### PR TITLE
Fix loadgenerator not all arguments converted during string formatting

### DIFF
--- a/src/loadgenerator/locustfile.py
+++ b/src/loadgenerator/locustfile.py
@@ -124,7 +124,7 @@ class WebsiteUser(HttpUser):
         duration = time.time() - start_time
         # skip checkout if the latency is more than a second
         if (self.skip_checkout(duration)):
-            logging.info("skipping checkout, duration:", duration)
+            logging.info(f"skipping checkout, duration: {duration}")
             return
         checkout_person = random.choice(people)
         checkout_person["userId"] = user
@@ -142,7 +142,7 @@ class WebsiteUser(HttpUser):
         duration = time.time() - start_time
         # skip checkout if the latency is more than a second
         if (self.skip_checkout(duration)):
-            logging.info("skipping checkout_multi, duration:", duration)
+            logging.info(f"skipping checkout_multi, duration: {duration}")
             return
 
         checkout_person = random.choice(people)


### PR DESCRIPTION
# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts

The error
```
Message: 'skipping checkout, duration:'
Arguments: (1.1302261352539062,)
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/logging/__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "/usr/local/lib/python3.11/site-packages/locust/user/users.py", line 176, in run_user
    user.run()
  File "/usr/local/lib/python3.11/site-packages/locust/user/users.py", line 144, in run
    self._taskset_instance.run()
  File "/usr/local/lib/python3.11/site-packages/locust/user/task.py", line 347, in run
    self.execute_next_task()
  File "/usr/local/lib/python3.11/site-packages/locust/user/task.py", line 372, in execute_next_task
    self.execute_task(self._task_queue.pop(0))
  File "/usr/local/lib/python3.11/site-packages/locust/user/task.py", line 493, in execute_task
    task(self.user)
  File "/usr/src/app/locustfile.py", line 145, in checkout_multi
    logging.info("skipping checkout_multi, duration:", duration)
```