### PR TITLE
[D-313] Fix currency build issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,36 +7,14 @@ release.
 
 ## Unreleased
 
-* [grafana] update grafana to 10.2.3
-  ([#1332](https://github.com/open-telemetry/opentelemetry-demo/pull/1332))
-* [frontendproxy] Enable envoy environment resource detector
-  ([#1291](https://github.com/open-telemetry/opentelemetry-demo/pull/1291))
-* [currencyservice] - add package name prefix to `rpc.service` attribute
-  ([#1333](https://github.com/open-telemetry/opentelemetry-demo/pull/1333))
-* [currency] fix metric exporter options
-  ([#1335](https://github.com/open-telemetry/opentelemetry-demo/pull/1335))
-
-## 1.7.2
-
-* [cartservice] update .NET package to 1.7.0 release
-  ([#1326](https://github.com/open-telemetry/opentelemetry-demo/pull/1326))
-* [loadgenerator and recommendationservice] Update python base image
-  ([#1329](https://github.com/open-telemetry/opentelemetry-demo/pull/1329))
-
-## 1.7.1
-
-* [grafana] revert to 10.2.0
-* [cartservice] disable config reload
-  ([#1312](https://github.com/open-telemetry/opentelemetry-demo/pull/1312))
-* [cartservice] fixed cartServiceFailure feature flag
-  ([#1313](https://github.com/open-telemetry/opentelemetry-demo/pull/1313))
-* [accountingservice] Update dependencies and semconv
-* ([#1316](https://github.com/open-telemetry/opentelemetry-demo/pull/1316))
-* [featureflagservice] Allow setting initial feature flag values
-  ([#1319](https://github.com/open-telemetry/opentelemetry-demo/pull/1319))
-
-## 1.7.0
-
+* [currencyservice] bring back multistage build
+  ([#1276](https://github.com/open-telemetry/opentelemetry-demo/pull/1276))
+* [currencyservice]: update opentelemetry-cpp to 1.12.0
+  ([#1275](https://github.com/open-telemetry/opentelemetry-demo/pull/1275))
+* update loadgenerator dependencies and the base image
+  ([#1274](https://github.com/open-telemetry/opentelemetry-demo/pull/1274))
+* add env var for pinning trace-based test tool version
+  ([#1239](https://github.com/open-telemetry/opentelemetry-demo/pull/1239))
 * update PHP quoteservice to use 1.0.0
   ([#1236](https://github.com/open-telemetry/opentelemetry-demo/pull/1236))
 * Add ability to do probabilistic A/B testing with feature flags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ release.
 
 ## Unreleased
 
+* [grafana] update grafana to 10.2.3
+  ([#1332](https://github.com/open-telemetry/opentelemetry-demo/pull/1332))
+* [frontendproxy] Enable envoy environment resource detector
+  ([#1291](https://github.com/open-telemetry/opentelemetry-demo/pull/1291))
+* [currencyservice] - add package name prefix to `rpc.service` attribute
+  ([#1333](https://github.com/open-telemetry/opentelemetry-demo/pull/1333))
+* [currency] fix metric exporter options
+  ([#1335](https://github.com/open-telemetry/opentelemetry-demo/pull/1335))
+
+## 1.7.2
+
+* [cartservice] update .NET package to 1.7.0 release
+  ([#1326](https://github.com/open-telemetry/opentelemetry-demo/pull/1326))
+* [loadgenerator and recommendationservice] Update python base image
+  ([#1329](https://github.com/open-telemetry/opentelemetry-demo/pull/1329))
+
+## 1.7.1
+
+* [grafana] revert to 10.2.0
+* [cartservice] disable config reload
+  ([#1312](https://github.com/open-telemetry/opentelemetry-demo/pull/1312))
+* [cartservice] fixed cartServiceFailure feature flag
+  ([#1313](https://github.com/open-telemetry/opentelemetry-demo/pull/1313))
+* [accountingservice] Update dependencies and semconv
+* ([#1316](https://github.com/open-telemetry/opentelemetry-demo/pull/1316))
+* [featureflagservice] Allow setting initial feature flag values
+  ([#1319](https://github.com/open-telemetry/opentelemetry-demo/pull/1319))
+
+## 1.7.0
+
+* update PHP quoteservice to use 1.0.0
+  ([#1236](https://github.com/open-telemetry/opentelemetry-demo/pull/1236))
+* Add ability to do probabilistic A/B testing with feature flags
+  ([#1237](https://github.com/open-telemetry/opentelemetry-demo/pull/1237))
+* add env var for pinning trace-based test tool version
+  ([#1239](https://github.com/open-telemetry/opentelemetry-demo/pull/1239))
+* [cartservice] Add .NET memory, CPU, and thread metrics
+  ([#1265](https://github.com/open-telemetry/opentelemetry-demo/pull/1265))
+* [cartservice] update .NET to .NET 8.0
+  ([#1272](https://github.com/open-telemetry/opentelemetry-demo/pull/1272))
+* update loadgenerator dependencies and the base image
+  ([#1274](https://github.com/open-telemetry/opentelemetry-demo/pull/1274))
+* [currencyservice]: update opentelemetry-cpp to 1.12.0
+  ([#1275](https://github.com/open-telemetry/opentelemetry-demo/pull/1275))
+* [currencyservice] bring back multistage build
+  ([#1276](https://github.com/open-telemetry/opentelemetry-demo/pull/1276))
+* fix env var for pinning trace-based test tool version
+  ([#1283](https://github.com/open-telemetry/opentelemetry-demo/pull/1283))
+* [accountingservice] Add additional attributes to Kafka spans
+  ([#1286](https://github.com/open-telemetry/opentelemetry-demo/pull/1286))
+* [shippingservice] update Rust OTel libraries to 0.21
+  ([#1287](https://github.com/open-telemetry/opentelemetry-demo/pull/1287))
+
+## 1.6.0
+
 * update PHP quoteservice to use RC1
   ([#1114](https://github.com/open-telemetry/opentelemetry-demo/pull/1114))
 * [cartservice] update .NET package to 1.6.0 release

--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -14,22 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine
+FROM alpine as builder
 
-RUN apk update
-RUN apk add git cmake make g++ grpc-dev re2-dev protobuf-dev c-ares-dev
+RUN apk update && apk add git cmake make g++ grpc-dev protobuf-dev
 
 ARG OPENTELEMETRY_CPP_VERSION=1.10.0
 
 RUN git clone https://github.com/open-telemetry/opentelemetry-cpp \
-	&& cd opentelemetry-cpp/ \
-    	&& git checkout tags/v${OPENTELEMETRY_CPP_VERSION} -b v${OPENTELEMETRY_CPP_VERSION} \
-	&& mkdir build \
-	&& cd build \
-	&& cmake .. -DCMAKE_CXX_STANDARD=17 -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-				-DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
-				-DWITH_EXAMPLES=OFF -DWITH_OTLP_GRPC=ON \
-	&& make -j$(nproc || sysctl -n hw.ncpu || echo 1) install && cd ../.. && rm -rf opentelemetry-cpp
+	  && cd opentelemetry-cpp/ \
+    && git checkout tags/v${OPENTELEMETRY_CPP_VERSION} -b v${OPENTELEMETRY_CPP_VERSION} \
+    && mkdir build \
+    && cd build \
+    && cmake .. -DCMAKE_CXX_STANDARD=17 -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
+          -DWITH_EXAMPLES=OFF -DWITH_OTLP_GRPC=ON \
+    && make -j$(nproc || sysctl -n hw.ncpu || echo 1) install && cd ../..
 
 COPY . /currencyservice
 
@@ -37,6 +36,12 @@ RUN cd /currencyservice \
     && mkdir -p build && cd build \
     && cmake .. \
     && make -j$(nproc || sysctl -n hw.ncpu || echo 1) install
+
+
+FROM alpine as release
+
+RUN apk update && apk add grpc-dev protobuf-dev
+COPY --from=builder /usr/local /usr/local
 
 EXPOSE ${CURRENCY_SERVICE_PORT}
 ENTRYPOINT ./usr/local/bin/currencyservice ${CURRENCY_SERVICE_PORT}

--- a/src/currencyservice/src/meter_common.h
+++ b/src/currencyservice/src/meter_common.h
@@ -24,15 +24,14 @@ namespace
   {
     // Build MetricExporter
     otlp_exporter::OtlpGrpcMetricExporterOptions otlpOptions;
-
     // Configuration via environment variable not supported yet
-    otlpOptions.aggregation_temporality = metric_sdk::AggregationTemporality::kDelta;
+    //otlpOptions.aggregation_temporality = otlp_exporter::PreferredAggregationTemporality::kCumulative;
     auto exporter = otlp_exporter::OtlpGrpcMetricExporterFactory::Create(otlpOptions);
 
     // Build MeterProvider and Reader
     metric_sdk::PeriodicExportingMetricReaderOptions options;
-    options.export_interval_millis = std::chrono::milliseconds(1000);
-    options.export_timeout_millis = std::chrono::milliseconds(500);
+    //options.export_interval_millis = std::chrono::milliseconds(60000);
+    //options.export_timeout_millis = std::chrono::milliseconds(30000);
     std::unique_ptr<metric_sdk::MetricReader> reader{
         new metric_sdk::PeriodicExportingMetricReader(std::move(exporter), options) };
     auto provider = std::shared_ptr<metrics_api::MeterProvider>(new metric_sdk::MeterProvider());


### PR DESCRIPTION
Pulled two commits from main in order to fix currency service build failure:

 - open-telemetry/opentelemetry-demo/pull/1335
  - 
 - open-telemetry/opentelemetry-demo/pull/1296
   - Pin alpine to 3.18
   - C++ 1.13.0 is being used by dependent libraries, so C++ version was updated
 
Both of these changes are required to remain compatible with [open-telemetry/opentelemetry-cpp](https://github.com/open-telemetry/opentelemetry-cpp)

