### PR TITLE
Enable admin api in prometheus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -680,6 +680,7 @@ services:
       - --web.route-prefix=/
       - --enable-feature=exemplar-storage
       - --enable-feature=otlp-write-receiver
+      - --web.enable-admin-api
     volumes:
       - ./src/prometheus/prometheus-config.yaml:/etc/prometheus/prometheus-config.yaml
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ networks:
   default:
     name: opentelemetry-demo
     driver: bridge
+    external: true
 
 services:
   # ******************


### PR DESCRIPTION
Admin api is needed to take prometheus db snapshot