### PR TITLE
Pass the newrelic api key Environment Variable into the Container

### DIFF
--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -521,6 +521,7 @@ services:
     logging: *logging
     environment:
       - ENVOY_PORT
+      - NEW_RELIC_API_KEY=${NEW_RELIC_API_KEY}
 
   # Prometheus
   prometheus:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -666,6 +666,7 @@ services:
     logging: *logging
     environment:
       - ENVOY_PORT
+      - NEW_RELIC_API_KEY=${NEW_RELIC_API_KEY}
 
   # Prometheus
   prometheus:


### PR DESCRIPTION
# Changes

This as a result, pass down the key and make the export logs works for newrelic:
```
❯ docker ps|grep col
66f11345a64a   otel/opentelemetry-collector-contrib:0.86.0               "/otelcol-contrib --…"   58 seconds ago   Up 57 seconds             55678-55679/tcp, 0.0.0.0:33000->4317/tcp, [::]:33000->4317/tcp, 0.0.0.0:33001->4318/tcp, [::]:33001->4318/tcp                                             otel-col
❯ docker logs 66f11345a64a -f
2025-02-07T17:26:24.987Z        info    service@v0.86.0/telemetry.go:84 Setting up own telemetry...
2025-02-07T17:26:24.990Z        info    service@v0.86.0/telemetry.go:201        Serving Prometheus metrics      {"address": ":8888", "level": "Basic"}
2025-02-07T17:26:24.992Z        info    exporter@v0.86.0/exporter.go:275        Development component. May change in the future.        {"kind": "exporter", "data_type": "traces", "name": "debug"}
2025-02-07T17:26:24.995Z        info    exporter@v0.86.0/exporter.go:275        Development component. May change in the future.        {"kind": "exporter", "data_type": "metrics", "name": "debug"}
2025-02-07T17:26:24.997Z        info    spanmetricsconnector@v0.86.0/connector.go:98    Building spanmetrics connector  {"kind": "exporter", "name": "spanmetrics", "exporter_in_pipeline": "traces", "receiver_in_pipeline": "metrics"}
2025-02-07T17:26:25.004Z        info    receiver@v0.86.0/receiver.go:296        Development component. May change in the future.        {"kind": "receiver", "name": "httpcheck/frontendproxy", "data_type": "metrics"}
2025-02-07T17:26:25.008Z        info    service@v0.86.0/service.go:138  Starting otelcol-contrib...     {"Version": "0.86.0", "NumCPU": 6}
2025-02-07T17:26:25.008Z        info    extensions/extensions.go:31     Starting extensions...
2025-02-07T17:26:25.009Z        info    spanmetricsconnector@v0.86.0/connector.go:167   Starting spanmetrics connector  {"kind": "exporter", "name": "spanmetrics", "exporter_in_pipeline": "traces", "receiver_in_pipeline": "metrics"}
2025-02-07T17:26:25.017Z        warn    internal@v0.86.0/warning.go:40  Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks     {"kind": "receiver", "name": "otlp", "data_type": "metrics", "documentation": "https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks"}
2025-02-07T17:26:25.019Z        info    otlpreceiver@v0.86.0/otlp.go:83 Starting GRPC server    {"kind": "receiver", "name": "otlp", "data_type": "metrics", "endpoint": "0.0.0.0:4317"}
2025-02-07T17:26:25.019Z        warn    internal@v0.86.0/warning.go:40  Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks     {"kind": "receiver", "name": "otlp", "data_type": "metrics", "documentation": "https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks"}
2025-02-07T17:26:25.019Z        info    otlpreceiver@v0.86.0/otlp.go:101        Starting HTTP server    {"kind": "receiver", "name": "otlp", "data_type": "metrics", "endpoint": "0.0.0.0:4318"}
2025-02-07T17:26:25.019Z        info    service@v0.86.0/service.go:161  Everything is ready. Begin running and processing data.
2025-02-07T17:26:26.204Z        info    MetricsExporter {"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 1, "metrics": 3, "data points": 7}
2025-02-07T17:26:40.074Z        info    MetricsExporter {"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 1, "metrics": 17, "data points": 48}
2025-02-07T17:26:59.643Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 1, "spans": 5}
2025-02-07T17:26:59.852Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 1, "spans": 5}
2025-02-07T17:27:01.673Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 4, "spans": 20}
2025-02-07T17:27:02.283Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 3, "spans": 15}
2025-02-07T17:27:03.118Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 6, "spans": 17}
2025-02-07T17:27:05.133Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 1, "spans": 1}
2025-02-07T17:27:05.742Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 1, "spans": 7}
2025-02-07T17:27:06.559Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 8, "spans": 41}
2025-02-07T17:27:06.788Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 10, "spans": 50}
2025-02-07T17:27:07.603Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 2, "spans": 10}
2025-02-07T17:27:07.810Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 2, "spans": 10}
2025-02-07T17:27:08.619Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 2, "spans": 10}
2025-02-07T17:27:09.425Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 3, "spans": 423}
2025-02-07T17:27:09.633Z        info    TracesExporter  {"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 2, "spans": 10}
2025-02-07T17:27:09.833Z        info    TracesExporter  {"k
```

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
